### PR TITLE
[NCL-7520] move task cleanup after final notification

### DIFF
--- a/core/src/main/java/org/jboss/pnc/rex/core/GenericVertxHttpClient.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/GenericVertxHttpClient.java
@@ -33,9 +33,12 @@ import org.jboss.pnc.rex.model.Header;
 import javax.enterprise.context.ApplicationScoped;
 import java.net.URI;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import static java.time.Duration.of;
 
 @Slf4j
 @ApplicationScoped
@@ -77,7 +80,9 @@ public class GenericVertxHttpClient {
                 .onItem().transformToUni(i -> Uni.createFrom()
                         .item(i)
                         .onItem().invoke(onResponse)
-                        .onFailure().retry().atMost(20)
+                        .onFailure().retry()
+                            .withBackOff(of(10, ChronoUnit.MILLIS), of(100, ChronoUnit.MILLIS))
+                            .atMost(20)
                         .onFailure().recoverWithNull())
                 .onFailure().invoke(t -> log.warn("HTTP-CLIENT : Http call failed. RETRYING. Reason: {}", t.toString()))
                 .onFailure().retry().atMost(20)

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/ChainingJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/ChainingJob.java
@@ -1,0 +1,129 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.core.jobs;
+
+import lombok.Getter;
+import org.jboss.pnc.rex.model.Task;
+
+import javax.enterprise.event.TransactionPhase;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Chained Jobs are executed SEQUENTIALLY in the order they were added to the chain. Jobs can trigger based on the
+ * result of previous Job from the sequence. For example, if the job succeeded or failed.
+ *
+ * The chaining and triggers rely on the return values of execute() method. Therefore, the Jobs must return proper
+ * boolean to see whether the execution failed or succeeded.
+ */
+public class ChainingJob extends ControllerJob {
+
+    @Getter
+    private final List<ControllerJob> chainLinks = new ArrayList<>();
+
+    private final Map<ControllerJob, ChainTrigger> chainTriggers = new HashMap<>();
+
+    /**
+     * Copy the execution profile from the initial task in chain.
+     *
+     * Throws NPE if firstChain is null.
+     *
+     * @param firstChain first task in chain
+     */
+    public ChainingJob(ControllerJob firstChain) {
+        super(firstChain.invocationPhase, firstChain.context, firstChain.async);
+
+        chain(firstChain, ChainTrigger.ON_ANY_OUTCOME);
+    }
+
+    public ChainingJob(TransactionPhase invocationPhase, Task context, boolean async, ControllerJob firstChain) {
+        super(invocationPhase, context, async);
+
+        chain(firstChain, ChainTrigger.ON_ANY_OUTCOME);
+    }
+
+    public static ChainingJob of(ControllerJob firstChain) {
+        return new ChainingJob(firstChain);
+    }
+
+    public ChainingJob chain(ControllerJob link) {
+        return chain(link, ChainTrigger.ON_ANY_OUTCOME);
+    }
+
+    public ChainingJob chainOnSuccess(ControllerJob link) {
+        return chain(link, ChainTrigger.ON_SUCCESS);
+    }
+
+    public ChainingJob chainOnFailure(ControllerJob link) {
+        return chain(link, ChainTrigger.ON_FAILURE);
+    }
+
+    private ChainingJob chain(ControllerJob link, ChainTrigger trigger) {
+        if (link == null) {
+            throw new IllegalArgumentException("Job link cannot be null");
+        }
+        chainLinks.add(link);
+        chainTriggers.put(link, trigger);
+
+        return this;
+    }
+
+    @Override
+    void beforeExecute() {}
+
+    @Override
+    void afterExecute() {}
+
+    @Override
+    boolean execute() {
+        boolean lastResult = true;
+        for (ControllerJob toRun : chainLinks) {
+            ChainTrigger toRunTrigger = chainTriggers.get(toRun);
+
+            boolean shouldRun = switch (toRunTrigger) {
+                case ON_SUCCESS -> lastResult;
+                case ON_FAILURE -> !lastResult;
+                case ON_ANY_OUTCOME -> true;
+            };
+
+            if (!shouldRun) {
+                break;
+            }
+
+            // RUN the task in chain
+            toRun.run();
+
+            lastResult = toRun.isSuccessful();
+        }
+        return lastResult;
+    }
+
+    @Override
+    void onFailure() {}
+
+    @Override
+    void onException(Throwable e) {}
+
+    private enum ChainTrigger {
+        ON_SUCCESS,
+        ON_FAILURE,
+        ON_ANY_OUTCOME
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/DecreaseCounterJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/DecreaseCounterJob.java
@@ -47,5 +47,8 @@ public class DecreaseCounterJob extends ControllerJob {
     }
 
     @Override
+    void onFailure() {}
+
+    @Override
     void onException(Throwable e) {}
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/DeleteTaskJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/DeleteTaskJob.java
@@ -41,17 +41,14 @@ public class DeleteTaskJob extends ControllerJob {
     }
 
     @Override
-    void afterExecute() {
-
-    }
+    void afterExecute() {}
 
     @Override
-    void beforeExecute() {
-
-    }
+    void beforeExecute() {}
 
     @Override
-    void onException(Throwable e) {
+    void onFailure() {}
 
-    }
+    @Override
+    void onException(Throwable e) {}
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/DependantMessageJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/DependantMessageJob.java
@@ -59,5 +59,8 @@ public abstract class DependantMessageJob extends ControllerJob {
     void afterExecute() {}
 
     @Override
+    void onFailure() {}
+
+    @Override
     void onException(Throwable e) {}
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/DependencyMessageJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/DependencyMessageJob.java
@@ -53,5 +53,8 @@ public abstract class DependencyMessageJob extends ControllerJob {
     void afterExecute() {}
 
     @Override
+    void onFailure() {}
+
+    @Override
     void onException(Throwable e) {}
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStartJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStartJob.java
@@ -58,6 +58,9 @@ public class InvokeStartJob extends ControllerJob {
     }
 
     @Override
+    void onFailure() {}
+
+    @Override
     void onException(Throwable e) {
         logger.error("STOP " + context.getName() + ": UNEXPECTED exception has been thrown.", e);
         Uni.createFrom().voidItem()

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStopJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStopJob.java
@@ -67,4 +67,7 @@ public class InvokeStopJob extends ControllerJob {
         client.stopJob(context);
         return true;
     }
+
+    @Override
+    void onFailure() {}
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/NotifyCallerJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/NotifyCallerJob.java
@@ -51,9 +51,11 @@ public class NotifyCallerJob extends ControllerJob {
 
     @Override
     boolean execute() {
-        client.notifyCaller(transition, context);
-        return true;
+        return client.notifyCaller(transition, context);
     }
+
+    @Override
+    void onFailure() {}
 
     @Override
     void onException(Throwable e) {

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/PokeQueueJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/PokeQueueJob.java
@@ -48,4 +48,7 @@ public class PokeQueueJob extends ControllerJob {
 
     @Override
     void onException(Throwable e) {}
+
+    @Override
+    void onFailure() {}
 }

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -2,13 +2,15 @@ scheduler:
   baseUrl: ${BASE_URL}
   name: node
   options:
+    task-configuration:
+      clean: true
     concurrency:
       default: 5
     retry-policy:
       maxRetries: 15
       delay: 10
       jitter: 50
-      abortOn: javax.validation.ConstraintViolationException, org.jboss.pnc.rex.common.exceptions.TaskMissingException, org.jboss.pnc.rex.common.exceptions.BadRequestException, org.jboss.pnc.rex.common.exceptions.TaskConflictException, org.jboss.pnc.rex.common.exceptions.CircularDependencyException
+      abortOn: javax.validation.ConstraintViolationException, org.jboss.pnc.rex.common.exceptions.TaskMissingException, org.jboss.pnc.rex.common.exceptions.BadRequestException, org.jboss.pnc.rex.common.exceptions.TaskConflictException, org.jboss.pnc.rex.common.exceptions.CircularDependencyException, org.jboss.pnc.rex.common.exceptions.ConstraintConflictException
 
 quarkus:
   package:
@@ -110,8 +112,8 @@ org:
       client-intelligence: BASIC
       use-schema-registration: true
       use-auth: true
-      auth-username: admin
-      auth-password: password
+      username: admin
+      password: password
       cache:
         "rex-counter":
           configuration-uri: "counter-configuration.xml"
@@ -160,6 +162,9 @@ org:
           configuration-uri: "constraints-configuration.xml"
           near-cache-mode: invalidated
           near-cache-max-entries: 100
+      devservices:
+        #        image-name: "infinispan/server:13.0.5.Final-2"
+        image-name: "infinispan/server:14.0.2.Final"
     log:
       category:
         "org.jboss.pnc":

--- a/core/src/test/java/org/jboss/pnc/rex/core/NotificationDisableCleanTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/NotificationDisableCleanTest.java
@@ -1,0 +1,114 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.core;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
+import org.jboss.pnc.rex.api.InternalEndpoint;
+import org.jboss.pnc.rex.api.TaskEndpoint;
+import org.jboss.pnc.rex.common.enums.State;
+import org.jboss.pnc.rex.core.common.TestData;
+import org.jboss.pnc.rex.core.common.TransitionRecorder;
+import org.jboss.pnc.rex.core.counter.Counter;
+import org.jboss.pnc.rex.core.counter.Running;
+import org.jboss.pnc.rex.core.endpoints.TransitionRecorderEndpoint;
+import org.jboss.pnc.rex.dto.TaskDTO;
+import org.jboss.pnc.rex.dto.requests.CreateGraphRequest;
+import org.jboss.pnc.rex.test.profile.WithoutTaskCleaning;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.pnc.rex.core.common.Assertions.waitTillTasksAre;
+import static org.jboss.pnc.rex.core.common.Assertions.waitTillTasksAreFinishedWith;
+import static org.jboss.pnc.rex.core.common.RandomDAGGeneration.generateDAG;
+import static org.jboss.pnc.rex.core.common.TestData.getComplexGraph;
+
+@QuarkusTest
+//@QuarkusTestResource(InfinispanResource.class) //Infinispan dev-services are used instead
+@TestSecurity(authorizationEnabled = false)
+@TestProfile(WithoutTaskCleaning.class) // disable deletion of tasks
+public class NotificationDisableCleanTest {
+
+    @Inject
+    TaskContainerImpl container;
+
+    @Inject
+    TaskEndpoint endpoint;
+
+    @Inject
+    InternalEndpoint internalEndpoint;
+
+    @Inject
+    @Running
+    Counter running;
+
+    @Inject
+    TransitionRecorderEndpoint recorderEndpoint;
+
+    @Inject
+    TransitionRecorder recorder;
+
+    @BeforeEach
+    void before() {
+        running.initialize(0L);
+        internalEndpoint.setConcurrent(10L);
+        recorderEndpoint.flush();
+        container.getCache().clear();
+    }
+
+    @AfterEach
+    public void after() throws InterruptedException {
+        recorder.clear();
+        Thread.sleep(100);
+    }
+
+    @Test
+    void testRecordedBodies() throws InterruptedException {
+        CreateGraphRequest request = getComplexGraph(true, true);
+        endpoint.start(request);
+        waitTillTasksAreFinishedWith(State.SUCCESSFUL, request.getVertices().keySet().toArray(new String[0]));
+
+        Thread.sleep(100);
+        Set<TaskDTO> all = endpoint.getAll(TestData.getAllParameters());
+        Predicate<TaskDTO> sizePredicate = (task) -> task.getServerResponses() != null
+                && task.getServerResponses().size() == 2;
+        Predicate<TaskDTO> responsePredicate = (task) -> {
+            var responses = task.getServerResponses();
+            boolean firstBody = responses.stream().anyMatch((response ->
+                    response.getState() == State.STARTING
+                    && response.getBody() instanceof Map
+                    && !((Map<String, String>) response.getBody()).get("task").isEmpty()));
+            boolean secondBody = responses.stream().anyMatch((response ->
+                    response.getState() == State.UP
+                    && response.getBody() instanceof String
+                    && response.getBody().equals("ALL IS OK")));
+            return firstBody && secondBody;
+        };
+        assertThat(all).isNotEmpty();
+        assertThat(all).allMatch(sizePredicate);
+        assertThat(all).allMatch(responsePredicate);
+    }
+}

--- a/core/src/test/java/org/jboss/pnc/rex/core/QueueTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/QueueTest.java
@@ -31,7 +31,6 @@ import org.jboss.pnc.rex.dto.TaskDTO;
 import org.jboss.pnc.rex.dto.requests.CreateGraphRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -146,7 +145,6 @@ public class QueueTest {
     }
 
     @Test
-    @Disabled
     void testRunningQueue() {
         internalEndpoint.setConcurrent(1L);
 

--- a/core/src/test/java/org/jboss/pnc/rex/core/TaskContainerImplTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/TaskContainerImplTest.java
@@ -331,7 +331,6 @@ class TaskContainerImplTest {
     }
 
     @Test
-    @Disabled
     public void testCancellationWithDependencies() throws Exception {
         String a = "a";
         String b = "b";
@@ -524,7 +523,6 @@ class TaskContainerImplTest {
         // sleep because running counter takes time to update
         Thread.sleep(50);
         assertThat(running.getValue()).isEqualTo(0);
-        // TODO Uncomment once NCL-7520 is completed
         assertThat(container.getTasks(true, true, true)).extracting("name", String.class)
                 .doesNotContain(randomDAG.getVertices().keySet().toArray(new String[0]));
     }

--- a/core/src/test/java/org/jboss/pnc/rex/core/common/RandomDAGGeneration.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/common/RandomDAGGeneration.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import static org.jboss.pnc.rex.core.common.TestData.getNotificationsRequest;
 import static org.jboss.pnc.rex.core.common.TestData.getRequestWithStart;
 import static org.jboss.pnc.rex.core.common.TestData.getStopRequest;
 
@@ -48,6 +49,21 @@ public class RandomDAGGeneration {
      * @return randomly generated DAG
      */
     public static CreateGraphRequest generateDAG(int seed, int minPerRank, int maxPerRank, int minRanks, int maxRanks, float edgeProbability) {
+        return generateDAG(seed, minPerRank, maxPerRank, minRanks, maxRanks, edgeProbability, false);
+    }
+
+    /**
+     * @param seed              seed used in pseudo-random generator
+     * @param minPerRank        minimum amount of nodes at a particular height of DAG
+     * @param maxPerRank        maximum amount of nodes at a particular height of DAG
+     * @param minRanks          minimum height of DAG
+     * @param maxRanks          maximum height of DAG
+     * @param edgeProbability   probability of an edge between node of lower rank and a node of a higher rank
+     * @param withNotifications
+     * @return randomly generated DAG
+     * @see <a href="https://stackoverflow.com/a/57321815">Link to algorithm rewritten from python to java</a>
+     */
+    public static CreateGraphRequest generateDAG(int seed, int minPerRank, int maxPerRank, int minRanks, int maxRanks, float edgeProbability, boolean withNotifications) {
         Random random = new Random(seed);
         int nodes = 0;
         int nodeCounter = 0;
@@ -86,6 +102,7 @@ public class RandomDAGGeneration {
                     .controllerMode(Mode.ACTIVE)
                     .remoteStart(getRequestWithStart(string))
                     .remoteCancel(getStopRequest(string))
+                    .callerNotifications(withNotifications ? getNotificationsRequest() : null)
                     .build());
         }
         builder.edges(egdes);

--- a/core/src/test/java/org/jboss/pnc/rex/core/common/TestData.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/common/TestData.java
@@ -109,6 +109,14 @@ public class TestData {
                 .attachment("hello")
                 .build();
     }
+    public static org.jboss.pnc.api.dto.Request getNaughtyNotificationsRequest() {
+        return org.jboss.pnc.api.dto.Request.builder()
+                .uri(URI.create("http://localhost:8081/transition/fail"))
+                .method(org.jboss.pnc.api.dto.Request.Method.POST)
+                .headers(List.of(new org.jboss.pnc.api.dto.Request.Header("Content-Type", "application/json")))
+                .attachment("hello")
+                .build();
+    }
 
     public static Request getEndpointWithStart(String payload) {
         return Request.builder()

--- a/core/src/test/java/org/jboss/pnc/rex/core/endpoints/TransitionRecorderEndpoint.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/endpoints/TransitionRecorderEndpoint.java
@@ -57,6 +57,16 @@ public class TransitionRecorderEndpoint {
         return Response.serverError().build();
     }
 
+    @POST
+    @Path("/fail")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response beBad(NotificationRequest request) {
+        if (request.getAfter().isFinal()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        return Response.ok().build();
+    }
+
     public void flush() {
         recorder.clear();
     }

--- a/core/src/test/java/org/jboss/pnc/rex/test/profile/WithoutTaskCleaning.java
+++ b/core/src/test/java/org/jboss/pnc/rex/test/profile/WithoutTaskCleaning.java
@@ -1,0 +1,35 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.test.profile;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class WithoutTaskCleaning implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("scheduler.options.task-configuration.clean", "false");
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "test";
+    }
+}

--- a/model/src/main/java/org/jboss/pnc/rex/model/Task.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/Task.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * <p>
  * TaskController manipulates Task's data.
  * <p>
- * Service has to be installed through BatchTaskInstaller that is provided by TaskTarget. After installation, Task's
+ * Task has to be installed through BatchTaskInstaller that is provided by TaskTarget. After installation, Task's
  * data is held by Infinispan cache inside TaskRegistry/TaskContainer.
  *
  * @author Jan Michalov <jmichalo@redhat.com>


### PR DESCRIPTION
2 main features:
- If a Task has an endpoint to notify, the Task may be cleaned after successful final notification at the earliest.
  - in case it doesn't have an endpoint to notify, the Task may be cleaned immediately after final transition 
- Cleanup is configurable globally and can be disabled altogether which shifts the responsibility to ISPN cache expiration