### PR TITLE
[NCL-7921] Make Rex be able to use previous task results in future tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bin
 
 # Generic
 env.prop
+.mvn/wrapper/maven-wrapper.jar

--- a/core/src/main/java/org/jboss/pnc/rex/core/mapper/InitialTaskMapper.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/mapper/InitialTaskMapper.java
@@ -39,5 +39,6 @@ public interface InitialTaskMapper {
     @Mapping(target = "serverResponse", ignore = true)
     @Mapping(target = "dependant", ignore = true)
     @Mapping(target = "dependency", ignore = true)
+    @Mapping(target = "previousTaskNameResults", ignore = true)
     Task fromInitialTask(InitialTask initialTask);
 }

--- a/dto/src/main/java/org/jboss/pnc/rex/dto/TaskDTO.java
+++ b/dto/src/main/java/org/jboss/pnc/rex/dto/TaskDTO.java
@@ -60,4 +60,6 @@ public class TaskDTO {
     public Set<String> dependants = new HashSet<>();
 
     public Set<String> dependencies = new HashSet<>();
+
+    private List<String> previousTaskNameResults = new ArrayList<>();
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/Task.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/Task.java
@@ -143,6 +143,10 @@ public class Task {
     @Getter(onMethod_ = @ProtoField(number = 14, defaultValue = "false"))
     private Boolean starting;
 
+    @Getter(onMethod_ = @ProtoField(number = 15))
+    private List<String> previousTaskNameResults = new ArrayList<>();
+
+
     public void incUnfinishedDependencies() {
         unfinishedDependencies++;
     }

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/MinimizedTask.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/MinimizedTask.java
@@ -59,4 +59,6 @@ public class MinimizedTask {
     private final List<ServerResponse> serverResponses;
 
     private final StopFlag stopFlag;
+
+    private final List<String> previousTaskNameResults;
 }


### PR DESCRIPTION
Add ability to specify in a task that you would like to also include results from previous tasks in the payload (body)

This is done by specifying a list of `previousTaskNames` in the task definition.

The previous task names will have to be:

- in final state
- in the same graph as the current task

to be considered valid.

If the `previousTaskNames` is specified, a list is returned as payload if more than 1 item is being used; the results and finally the original payload of the task.