### PR TITLE
[NCL-8001] Produce rex jar with jakarta annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ successful/unsuccessful completion of remote tasks. Additionally, there is an op
 for a task which will make Rex publish notifications as the task transitions between states.
 
 
-
 # Running rex
 
 ## Requirements
@@ -79,3 +78,47 @@ for a task which will make Rex publish notifications as the task transitions bet
 
 ## Container image build
 - mvn clean install -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true
+
+## Consuming rex-api in a Quarkus 3 application
+Rex is currently based on Quarkus 2 which uses Jakarta EE 8. For any
+application built on top of Quarkus 3 and/or Jakarta EE 9+ and consuming the
+rex-api library, the following changes are needed in the application's pom.xml:
+
+```xml
+<dependency>
+  <groupId>org.jboss.pnc.rex</groupId>
+  <artifactId>rex-api</artifactId>
+  <version>LATEST</version>
+  <classifier>jakarta</classifier>
+  <exclusions>
+    <exclusion>
+      <groupId>org.jboss.pnc.rex</groupId>
+      <artifactId>rex-dto</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+<dependency>
+  <groupId>org.jboss.pnc.rex</groupId>
+  <artifactId>rex-dto</artifactId>
+  <version>LATEST</version>
+  <classifier>jakarta</classifier>
+  <exclusions>
+    <exclusion>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>pnc-api</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+<dependency>
+  <groupId>org.jboss.pnc</groupId>
+  <artifactId>pnc-api</artifactId>
+  <version>LATEST</version>
+  <classifier>jakarta</classifier>
+</dependency>
+```
+The rex-api with classifier `jakarta` is produced by the eclipse-transformer
+maven plugin to modify the rex-api jar to port to `jakarta` import statements.
+However this transformation doesn't take care of transitive dependencies. Since rex-dto also uses `javax` import statements, we need to:
+- explicitly exclude rex-dto when using rex-api
+- explicitly specify that we want to use the rex-dto with classifier `jakarta` and explicity exclude pnc-api
+- explicitly specify that we want to use pnc-api with classifier `jakarta`

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -49,5 +49,27 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.version}</version>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/dto/pom.xml
+++ b/dto/pom.xml
@@ -57,4 +57,27 @@
             <artifactId>pnc-api</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.version}</version>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,18 @@
             </excludes>
           </configuration>
         </plugin>
+        <plugin>
+            <groupId>org.eclipse.transformer</groupId>
+            <artifactId>transformer-maven-plugin</artifactId>
+            <version>0.5.0</version>
+            <extensions>true</extensions>
+            <configuration>
+                <rules>
+                    <jakartaDefaults>true</jakartaDefaults>
+                </rules>
+                <classifier>jakarta</classifier>
+            </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
The rex jars for now are:
- rex-api
- rex-dto

This is done using the Eclipse Transformer Maven plugin. We run the default jar through the plugin to spit out the jar with classifier jakarta.

You can then consume either the javax jar (default) or the jakarta jar (with classifier jakarta) in your project.

The README is also updated on how to consume the jakarta jars in a project's library.