### PR TITLE
[NCL-8132] Specify new roles for Rex

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,9 @@ However this transformation doesn't take care of transitive dependencies. Since 
 - explicitly exclude rex-dto when using rex-api
 - explicitly specify that we want to use the rex-dto with classifier `jakarta` and explicity exclude pnc-api
 - explicitly specify that we want to use pnc-api with classifier `jakarta`
+
+# Authentication
+Rex is authentication using OIDC. Three roles are used:
+- `pnc-users-rex-user`: Regular Rex user permissions for some endpoints
+- `pnc-users-rex-admin`: Admin permissions for all endpoints
+- `pnc-users-admin`: Admin permissions for all endpoints

--- a/core/src/main/java/org/jboss/pnc/rex/rest/InternalEndpointImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/rest/InternalEndpointImpl.java
@@ -50,7 +50,7 @@ public class InternalEndpointImpl implements InternalEndpoint {
     @Override
     @Retry
     @Fallback(fallbackMethod = "fallback", applyOn = {RollbackException.class, ArcUndeclaredThrowableException.class})
-    @RolesAllowed("user")
+    @RolesAllowed({ "pnc-users-rex-admin", "pnc-users-rex-user", "pnc-users-admin" })
     @Deprecated
     public void finish(String taskName, FinishRequest result) {
         taskProvider.acceptRemoteResponse(taskName, result.getStatus(), result.getResponse());
@@ -59,7 +59,7 @@ public class InternalEndpointImpl implements InternalEndpoint {
     @Override
     @Retry
     @Fallback(fallbackMethod = "objectFallback", applyOn = {RollbackException.class, ArcUndeclaredThrowableException.class})
-    @RolesAllowed("user")
+    @RolesAllowed({ "pnc-users-rex-admin", "pnc-users-rex-user", "pnc-users-admin" })
     public void succeed(String taskName, Object result) {
         taskProvider.acceptRemoteResponse(taskName, true, result);
     }
@@ -67,14 +67,14 @@ public class InternalEndpointImpl implements InternalEndpoint {
     @Override
     @Retry
     @Fallback(fallbackMethod = "objectFallback", applyOn = {RollbackException.class, ArcUndeclaredThrowableException.class})
-    @RolesAllowed("user")
+    @RolesAllowed({ "pnc-users-rex-admin", "pnc-users-rex-user", "pnc-users-admin" })
     public void fail(String taskName, Object result) {
         taskProvider.acceptRemoteResponse(taskName, false, result);
     }
 
     @Override
     @Retry
-    @RolesAllowed("system-user")
+    @RolesAllowed({ "pnc-users-rex-admin", "pnc-users-admin" })
     public void setConcurrent(Long amount) {
         optionsProvider.setConcurrency(amount);
     }

--- a/core/src/main/java/org/jboss/pnc/rex/rest/TaskEndpointImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/rest/TaskEndpointImpl.java
@@ -41,7 +41,7 @@ public class TaskEndpointImpl implements TaskEndpoint {
 
     @Override
     @Retry
-    @RolesAllowed("user")
+    @RolesAllowed({ "pnc-users-rex-admin", "pnc-users-rex-user", "pnc-users-admin" })
     public Set<TaskDTO> start(CreateGraphRequest request) {
         return taskProvider.create(request);
     }
@@ -69,7 +69,7 @@ public class TaskEndpointImpl implements TaskEndpoint {
 
     @Override
     @Retry
-    @RolesAllowed("user")
+    @RolesAllowed({ "pnc-users-rex-admin", "pnc-users-rex-user", "pnc-users-admin" })
     public void cancel(String taskID) {
         taskProvider.cancel(taskID);
     }

--- a/core/src/test/java/org/jboss/pnc/rex/core/authentication/AuthenticationTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/authentication/AuthenticationTest.java
@@ -60,7 +60,7 @@ public class AuthenticationTest {
     @Test
     void testWithUserAuthentication() {
         given()
-                .auth().oauth2(getAccessToken("alice", Set.of("user")))
+                .auth().oauth2(getAccessToken("alice", Set.of("pnc-users-rex-user")))
                 .when()
                 .contentType(ContentType.JSON)
                 .put(taskEndpointURI.getPath()+"/missing/cancel")
@@ -72,7 +72,7 @@ public class AuthenticationTest {
     @Test
     void testWithAdminAuthentication() {
         given()
-                .auth().oauth2(getAccessToken("admin", Set.of("system-user")))
+                .auth().oauth2(getAccessToken("admin", Set.of("pnc-users-rex-admin")))
                 .when()
                 .contentType(ContentType.JSON)
                 .post(internalEndpointURI.getPath()+"/options/concurrency?amount=40")


### PR DESCRIPTION
With the authorization initiative, we need to restrict who can access Rex. With that in mind, we'll allow users with roles:

- pnc-users-rex-admin (mostly service accounts)
- pnc-users-admin (human PNC developers)

to interact with Rex.

This is needed as we also start using a unique service account for Rex (NCL-8054) to trigger the task endpoints. That service account might have special roles which not all users should be able to indirectly invoke.