### PR TITLE
[NCL-8054] Use service account when for start and stop job

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,6 +93,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-config-yaml</artifactId>
         </dependency>
         <dependency>

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -45,6 +45,12 @@ quarkus:
     application-type: SERVICE
     tls:
       verification: none
+  oidc-client:
+    enabled: true
+    auth-server-url: https://keycloak.com/auth/realms/quarkus
+    client-id: client
+    credentials:
+      secret: secret
 
   infinispan-client:
 #    hosts: ${ISPN_NODE}
@@ -129,6 +135,8 @@ org:
     oidc:
       enabled: false
       auth-server-url: ""
+    oidc-client:
+      enabled: false
     transaction-manager:
       default-transaction-timeout: 10m
     http:

--- a/core/src/test/java/org/jboss/pnc/rex/core/BeanFactory.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/BeanFactory.java
@@ -1,0 +1,42 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.core;
+
+import io.quarkus.oidc.client.Tokens;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class BeanFactory {
+
+    /**
+     * Return a mock Tokens object to make the gods of CI happy
+     * @return Tokens object
+     */
+    @Produces
+    public Tokens getToken() {
+        return new Tokens(
+                "abcd",
+                0L,
+                null,
+                "abcd",
+                0L,
+                null);
+    }
+}


### PR DESCRIPTION
This is required since the user shouldn't be sending access token HTTP headers in the original request; that access token will expire quickly.

Instead, we can use our own service account to add fresh HTTP authorization header.