### PR TITLE
[NCL-7944] Add ability to skip callback

### DIFF
--- a/common/src/main/java/org/jboss/pnc/rex/common/enums/Transition.java
+++ b/common/src/main/java/org/jboss/pnc/rex/common/enums/Transition.java
@@ -145,7 +145,19 @@ public enum Transition {
      * Controller informs Task's dependants that it successfully finished.
      */
     @ProtoEnumValue(number = 16)
-    UP_to_SUCCESSFUL(State.UP, State.SUCCESSFUL);
+    UP_to_SUCCESSFUL(State.UP, State.SUCCESSFUL),
+    /**
+     * Controller received positive response that remote Task has successfully started and finished its execution.
+     * We use this when a callback is not necessary
+     */
+    @ProtoEnumValue(number = 17)
+    STARTING_to_SUCCESSFUL(State.STARTING, State.SUCCESSFUL),
+    /**
+     * Controller received positive response that remote Task has successfully stopped and finished its execution.
+     * We use this when a callback is not necessary
+     */
+    @ProtoEnumValue(number = 18)
+    STOP_REQUESTED_to_STOPPED(State.STOP_REQUESTED, State.STOPPED);
 
     private final State before;
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/RemoteEntityClient.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/RemoteEntityClient.java
@@ -41,7 +41,9 @@ import org.jboss.pnc.rex.model.Header;
 import org.jboss.pnc.rex.model.Request;
 import org.jboss.pnc.rex.model.Task;
 import org.jboss.pnc.rex.model.requests.StartRequest;
+import org.jboss.pnc.rex.model.requests.StartRequestWithCallback;
 import org.jboss.pnc.rex.model.requests.StopRequest;
+import org.jboss.pnc.rex.model.requests.StopRequestWithCallback;
 import org.slf4j.MDC;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -133,14 +135,23 @@ public class RemoteEntityClient {
         org.jboss.pnc.api.dto.Request positiveCallback = getCallbackRequest(task.getName(), SUCCESS_ENDPOINT_PATH);
         org.jboss.pnc.api.dto.Request negativeCallback = getCallbackRequest(task.getName(), FAILED_ENDPOINT_PATH);
 
-        StopRequest request = StopRequest.builder()
-                .payload(requestDefinition.getAttachment())
-                .taskResults(getTaskResultsIfConfigurationAllows(task))
-                .callback(callbackRequest)
-                .positiveCallback(positiveCallback)
-                .negativeCallback(negativeCallback)
-                .mdc(getOptionalMDCAndOTELValues(task))
-                .build();
+        StopRequest request = null;
+        if (task.getConfiguration() != null && task.getConfiguration().isSkipStopRequestCallback()) {
+            request = StopRequest.builder()
+                    .payload(requestDefinition.getAttachment())
+                    .taskResults(getTaskResultsIfConfigurationAllows(task))
+                    .mdc(getOptionalMDCAndOTELValues(task))
+                    .build();
+        } else {
+            request = StopRequestWithCallback.builder()
+                    .payload(requestDefinition.getAttachment())
+                    .taskResults(getTaskResultsIfConfigurationAllows(task))
+                    .callback(callbackRequest)
+                    .positiveCallback(positiveCallback)
+                    .negativeCallback(negativeCallback)
+                    .mdc(getOptionalMDCAndOTELValues(task))
+                    .build();
+        }
 
         client.makeRequest(url,
                 requestDefinition.getMethod(),
@@ -200,14 +211,23 @@ public class RemoteEntityClient {
         org.jboss.pnc.api.dto.Request positiveCallback = getCallbackRequest(task.getName(), SUCCESS_ENDPOINT_PATH);
         org.jboss.pnc.api.dto.Request negativeCallback = getCallbackRequest(task.getName(), FAILED_ENDPOINT_PATH);
 
-        StartRequest request = StartRequest.builder()
-                .payload(requestDefinition.getAttachment())
-                .taskResults(getTaskResultsIfConfigurationAllows(task))
-                .callback(callbackRequest)
-                .positiveCallback(positiveCallback)
-                .negativeCallback(negativeCallback)
-                .mdc(getOptionalMDCAndOTELValues(task))
-                .build();
+        StartRequest request = null;
+        if (task.getConfiguration() != null && task.getConfiguration().isSkipStartRequestCallback()) {
+            request = StartRequest.builder()
+                    .payload(requestDefinition.getAttachment())
+                    .taskResults(getTaskResultsIfConfigurationAllows(task))
+                    .mdc(getOptionalMDCAndOTELValues(task))
+                    .build();
+        } else {
+            request = StartRequestWithCallback.builder()
+                    .payload(requestDefinition.getAttachment())
+                    .taskResults(getTaskResultsIfConfigurationAllows(task))
+                    .callback(callbackRequest)
+                    .positiveCallback(positiveCallback)
+                    .negativeCallback(negativeCallback)
+                    .mdc(getOptionalMDCAndOTELValues(task))
+                    .build();
+        }
 
         client.makeRequest(uri,
                 requestDefinition.getMethod(),

--- a/core/src/main/java/org/jboss/pnc/rex/facade/mapper/ConfigurationMapper.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/mapper/ConfigurationMapper.java
@@ -36,5 +36,7 @@ public interface ConfigurationMapper extends EntityMapper<ConfigurationDTO, Conf
     @Mapping(target = "passResultsOfDependencies", defaultValue = "" + Defaults.passResultsOfDependencies)
     @Mapping(target = "passMDCInRequestBody", defaultValue = "" + Defaults.passMDCInRequestBody)
     @Mapping(target = "passOTELInRequestBody", defaultValue = "" + Defaults.passOTELInRequestBody)
+    @Mapping(target = "skipStartRequestCallback", defaultValue = "" + Defaults.skipStartRequestCallback)
+    @Mapping(target = "skipStopRequestCallback", defaultValue = "" + Defaults.skipStopRequestCallback)
     Configuration toDB(ConfigurationDTO dtoEntity);
 }

--- a/core/src/main/java/org/jboss/pnc/rex/facade/mapper/GraphsMapper.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/mapper/GraphsMapper.java
@@ -91,7 +91,9 @@ public interface GraphsMapper extends EntityMapper<CreateGraphRequest, TaskGraph
                     graphConfig.passResultsOfDependencies,
                     graphConfig.passMDCInRequestBody,
                     graphConfig.passOTELInRequestBody,
-                    graphConfig.mdcHeaderKeyMapping);
+                    graphConfig.mdcHeaderKeyMapping,
+                    graphConfig.skipStartRequestCallback,
+                    graphConfig.skipStopRequestCallback);
         }
 
         Boolean passResultsOfDependencies = taskConfig.passResultsOfDependencies;
@@ -110,11 +112,21 @@ public interface GraphsMapper extends EntityMapper<CreateGraphRequest, TaskGraph
         if (taskConfig.mdcHeaderKeyMapping == null && graphConfig.mdcHeaderKeyMapping != null) {
             mdcHeaderKeys = graphConfig.mdcHeaderKeyMapping;
         }
+        Boolean skipStartRequestCallback = taskConfig.skipStartRequestCallback;
+        if (taskConfig.skipStartRequestCallback == null && graphConfig.skipStartRequestCallback != null) {
+            skipStartRequestCallback = graphConfig.skipStartRequestCallback;
+        }
+        Boolean skipStopRequestCallback = taskConfig.skipStopRequestCallback;
+        if (taskConfig.skipStopRequestCallback == null && graphConfig.skipStopRequestCallback != null) {
+            skipStopRequestCallback = graphConfig.skipStopRequestCallback;
+        }
 
         return new ConfigurationDTO(
                 passResultsOfDependencies,
                 passMDCInRequestBody,
                 passOTELInRequestBody,
-                mdcHeaderKeys);
+                mdcHeaderKeys,
+                skipStartRequestCallback,
+                skipStopRequestCallback);
     }
 }

--- a/core/src/test/java/org/jboss/pnc/rex/core/endpoints/HttpEndpoint.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/endpoints/HttpEndpoint.java
@@ -27,8 +27,8 @@ import org.jboss.pnc.rex.core.GenericVertxHttpClient;
 import org.jboss.pnc.rex.core.counter.Counter;
 import org.jboss.pnc.rex.core.counter.Running;
 import org.jboss.pnc.rex.model.Header;
-import org.jboss.pnc.rex.model.requests.StartRequest;
-import org.jboss.pnc.rex.model.requests.StopRequest;
+import org.jboss.pnc.rex.model.requests.StartRequestWithCallback;
+import org.jboss.pnc.rex.model.requests.StopRequestWithCallback;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -87,7 +87,7 @@ public class HttpEndpoint {
     @POST
     @Path("/stopAndCallback")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response stopAndCallback(StopRequest request) {
+    public Response stopAndCallback(StopRequestWithCallback request) {
         record(request);
         executor.submit(() -> finishTask(request.getPositiveCallback()));
         return Response.ok().build();
@@ -96,7 +96,7 @@ public class HttpEndpoint {
     @POST
     @Path("/acceptAndStart")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response acceptAndStart(StartRequest request) {
+    public Response acceptAndStart(StartRequestWithCallback request) {
         record(request);
         executor.submit(() -> finishTask(request.getPositiveCallback()));
         return Response.ok("{\"task\": \"" + request.getPayload() + "\"}").build();
@@ -105,7 +105,7 @@ public class HttpEndpoint {
     @POST
     @Path("/acceptAndFail")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response acceptAndFail(StartRequest request) {
+    public Response acceptAndFail(StartRequestWithCallback request) {
         record(request);
         executor.submit(() -> finishTask(request.getNegativeCallback()));
         return Response.ok("{\"task\": \"" + request.getPayload() + "\"}").build();
@@ -115,7 +115,7 @@ public class HttpEndpoint {
     @Path("/425eventuallyOK")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response eventuallyAccept(StartRequest request, @QueryParam("fails") int fails) {
+    public Response eventuallyAccept(StartRequestWithCallback request, @QueryParam("fails") int fails) {
 
         if (fails == counter.get()) {
             executor.submit(() -> finishTask(request.getPositiveCallback()));

--- a/dto/src/main/java/org/jboss/pnc/rex/dto/ConfigurationDTO.java
+++ b/dto/src/main/java/org/jboss/pnc/rex/dto/ConfigurationDTO.java
@@ -42,4 +42,8 @@ public class ConfigurationDTO {
     public Boolean passOTELInRequestBody = null;
 
     public Map<String, String> mdcHeaderKeyMapping = null;
+
+    public Boolean skipStartRequestCallback = null;
+
+    public Boolean skipStopRequestCallback = null;
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/Configuration.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/Configuration.java
@@ -25,8 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoField;
 
-import java.beans.ConstructorProperties;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,6 +64,21 @@ public class Configuration {
      */
     private final HashMap<String, String> mdcHeaderKeyMapping;
 
+    /**
+     * Specify whether we want to accept the response to StartRequest as the final data (true), or not (false: default)
+     * The effect is that we don't need to receive a callback if true
+     */
+    @Getter(onMethod_ = {@ProtoField(number = 5, defaultValue = "" + Defaults.skipStartRequestCallback)})
+    private final boolean skipStartRequestCallback;
+
+    /**
+     * Specify whether we want to accept the response to StopRequest as the final data (true), or not (false: default)
+     * The effect is that we don't need to receive a callback if true
+     */
+    @Getter(onMethod_ = {@ProtoField(number = 6, defaultValue = "" + Defaults.skipStopRequestCallback)})
+    private final boolean skipStopRequestCallback;
+
+
     @ProtoField(number = 4, javaType = HashMap.class)
     public Map<String, String> getMdcHeaderKeyMapping() {
         return mdcHeaderKeyMapping;
@@ -75,5 +88,9 @@ public class Configuration {
         public static final boolean passResultsOfDependencies = false;
         public static final boolean passMDCInRequestBody = false;
         public static final boolean passOTELInRequestBody = false;
+
+        public static final boolean skipStartRequestCallback = false;
+
+        public static final boolean skipStopRequestCallback = false;
     }
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/StartRequestWithCallback.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/StartRequestWithCallback.java
@@ -22,20 +22,30 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.Map;
-
 /**
- * Request sent to the remote entity to start execution of remote Task.
+ * Request sent to the remote entity to start execution of remote Task, with extra fields for callback endpoints
  */
 @Jacksonized
 @SuperBuilder
 @Getter
 @ToString
-public class StartRequest {
+public class StartRequestWithCallback extends StartRequest {
+    /**
+     * The referenced endpoint is application/JSON only and serves for both positive and negative callback.
+     * Additionally, it uses a specific JSON body
+     *
+     * Don't use it
+     */
+    @Deprecated
+    private final org.jboss.pnc.api.dto.Request callback;
 
-    private final Object payload;
+    /**
+     * The referenced endpoint is generic and serves for positive callback.
+     */
+    private final org.jboss.pnc.api.dto.Request positiveCallback;
 
-    private final Map<String, String> mdc;
-
-    private final Map<String, Object> taskResults;
+    /**
+     * The referenced endpoint is generic and serves for negative callback.
+     */
+    private final org.jboss.pnc.api.dto.Request negativeCallback;
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequest.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequest.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.rex.model.requests;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
 import java.util.Map;
@@ -28,29 +28,10 @@ import java.util.Map;
  * Request sent to the remote entity to cancel execution of remote Task.
  */
 @Jacksonized
-@Builder
+@SuperBuilder
 @Getter
 @ToString
 public class StopRequest {
-
-    /**
-     * The referenced endpoint is application/JSON only and serves for both positive and negative callback.
-     * Additionally, it uses a specific JSON body
-     *
-     * Don't use it
-     */
-    @Deprecated
-    private final org.jboss.pnc.api.dto.Request callback;
-
-    /**
-     * The referenced endpoint is generic and serves for positive callback.
-     */
-    private final org.jboss.pnc.api.dto.Request positiveCallback;
-
-    /**
-     * The referenced endpoint is generic and serves for negative callback.
-     */
-    private final org.jboss.pnc.api.dto.Request negativeCallback;
 
     private final Object payload;
 

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequestWithCallback.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequestWithCallback.java
@@ -22,20 +22,30 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
-import java.util.Map;
-
 /**
- * Request sent to the remote entity to start execution of remote Task.
+ * Request sent to the remote entity to cancel execution of remote Task, with extra fields for callback endpoint
  */
 @Jacksonized
 @SuperBuilder
 @Getter
 @ToString
-public class StartRequest {
+public class StopRequestWithCallback extends StopRequest {
+    /**
+     * The referenced endpoint is application/JSON only and serves for both positive and negative callback.
+     * Additionally, it uses a specific JSON body
+     *
+     * Don't use it
+     */
+    @Deprecated
+    private final org.jboss.pnc.api.dto.Request callback;
 
-    private final Object payload;
+    /**
+     * The referenced endpoint is generic and serves for positive callback.
+     */
+    private final org.jboss.pnc.api.dto.Request positiveCallback;
 
-    private final Map<String, String> mdc;
-
-    private final Map<String, Object> taskResults;
+    /**
+     * The referenced endpoint is generic and serves for negative callback.
+     */
+    private final org.jboss.pnc.api.dto.Request negativeCallback;
 }


### PR DESCRIPTION
We can just use the data provided in the initial request. This is done by specifying a custom configuration where skipCallback is set to true.