### PR TITLE
[NCL-8164] fix race-condition resulting in deletion of tasks before notification

### DIFF
--- a/core/src/main/java/org/jboss/pnc/rex/core/CleaningManagerImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/CleaningManagerImpl.java
@@ -1,0 +1,64 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.core;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.rex.core.api.CleaningManager;
+import org.jboss.pnc.rex.core.api.TaskContainer;
+import org.jboss.pnc.rex.core.api.TaskController;
+import org.jboss.pnc.rex.model.Task;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@ApplicationScoped
+public class CleaningManagerImpl implements CleaningManager {
+
+    private final TaskContainer container;
+    private final TaskController controller;
+
+    public CleaningManagerImpl(TaskContainer container, TaskController controller) {
+        this.container = container;
+        this.controller = controller;
+    }
+
+    @Override
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public void tryClean() {
+        log.info("CLEANER: Querying for tasks ready for deletion.");
+
+        List<Task> tasksToDelete = container.getMarkedTasksWithoutDependants();
+
+        if (tasksToDelete.isEmpty()) {
+            log.info("CLEANER: No immediately disposable tasks were found.");
+            return;
+        }
+
+        log.info("CLEANER: Found {} top-level tasks for deletion {}. The deletion can cascade to their dependencies.",
+                tasksToDelete.size(),
+                tasksToDelete.stream().map(Task::getName).collect(Collectors.toList())
+        );
+
+        tasksToDelete.forEach(task -> controller.delete(task.getName()));
+
+        log.info("CLEANER: Cleaning completed.");
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/rex/core/QueueManagerImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/QueueManagerImpl.java
@@ -22,6 +22,7 @@ import org.infinispan.client.hotrod.VersionedValue;
 import org.jboss.pnc.rex.core.api.QueueManager;
 import org.jboss.pnc.rex.core.api.TaskContainer;
 import org.jboss.pnc.rex.core.api.TaskController;
+import org.jboss.pnc.rex.core.api.TaskRegistry;
 import org.jboss.pnc.rex.core.counter.Counter;
 import org.jboss.pnc.rex.core.counter.MaxConcurrent;
 import org.jboss.pnc.rex.core.counter.Running;
@@ -42,10 +43,10 @@ public class QueueManagerImpl implements QueueManager {
 
     private final Counter max;
     private final Counter running;
-    private final TaskContainer container;
+    private final TaskRegistry container;
     private final TaskController controller;
 
-    public QueueManagerImpl(@MaxConcurrent Counter max, @Running Counter running, TaskContainer container, TaskController controller) {
+    public QueueManagerImpl(@MaxConcurrent Counter max, @Running Counter running, TaskRegistry container, TaskController controller) {
         this.max = max;
         this.running = running;
         this.container = container;
@@ -71,7 +72,7 @@ public class QueueManagerImpl implements QueueManager {
 
         List<Task> randomEnqueuedTasks = container.getEnqueuedTasks(freeSpace);
 
-        if (randomEnqueuedTasks.size() == 0) {
+        if (randomEnqueuedTasks.isEmpty()) {
             return;
         }
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/api/CleaningManager.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/api/CleaningManager.java
@@ -1,0 +1,37 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.core.api;
+
+/**
+ * Independent manager for cleaning/disposing of Tasks in Rex.
+ */
+public interface CleaningManager {
+
+    /**
+     * Queries and deletes all Tasks that can be removed. The tasks have to be marked as disposable
+     * {@link org.jboss.pnc.rex.model.Task#disposable} and have no dependants. One-by-one the deletion is triggered on
+     * these tasks.
+     *
+     * Each deletion cascades on dependencies but the same conditions apply (marked + no dependants). For
+     * the cascaded dependencies, the dependant from which the deletion was triggered is at the time of triggering
+     * already removed (to retain conditions for removal).
+     *
+     * The method can be called at any time, even when there is nothing to clean.
+     */
+    void tryClean();
+}

--- a/core/src/main/java/org/jboss/pnc/rex/core/api/TaskController.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/api/TaskController.java
@@ -40,7 +40,7 @@ public interface TaskController {
     void setMode(String name, Mode mode);
 
     /**
-     * Sets mode of a Task. Needs to be called in a transaction. Additionally pokes queue
+     * Sets mode of a Task. Needs to be called in a transaction. Additionally, pokes queue
      * after transaction succeeds if specified.
      *
      * @param name id of the Task
@@ -70,7 +70,17 @@ public interface TaskController {
     /**
      * Deletes a Task. The method deletes also cascades on dependencies.
      *
+     * A Task can be removed only if all of its dependants are removed and is marked for disposal.
+     *
      * @param name id of the Task
      */
     void delete(String name);
+
+    /**
+     * Marks the Task for disposal/cleaning.
+     *
+     * @param name        id of thr Task
+     * @param pokeCleaner
+     */
+    void markForDisposal(String name, boolean pokeCleaner);
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/api/TaskRegistry.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/api/TaskRegistry.java
@@ -74,6 +74,14 @@ public interface TaskRegistry {
     List<Task> getTasksByCorrelationID(String correlationID);
 
     /**
+     * Return tasks that are marked disposable and do not have dependants. These tasks are suitable for immediate
+     * deletion.
+     *
+     * @return list of marked tasks without dependants
+     */
+    List<Task> getMarkedTasksWithoutDependants();
+
+    /**
      * Returns all task identifiers in clustered container.
      *
      * @return the service names

--- a/core/src/main/java/org/jboss/pnc/rex/core/config/api/HttpConfiguration.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/config/api/HttpConfiguration.java
@@ -38,7 +38,7 @@ public interface HttpConfiguration {
      *
      * @return time in milliseconds
      */
-    @WithDefault("30000") // 5 minutes
+    @WithDefault("300000") // 5 minutes
     @PositiveOrZero
     long idleTimeout();
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/delegates/TolerantQueueManager.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/delegates/TolerantQueueManager.java
@@ -17,12 +17,14 @@
  */
 package org.jboss.pnc.rex.core.delegates;
 
+import io.quarkus.arc.Unremovable;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.jboss.pnc.rex.core.api.QueueManager;
 
 import javax.enterprise.context.ApplicationScoped;
 
 @WithRetries
+@Unremovable
 @ApplicationScoped
 public class TolerantQueueManager implements QueueManager {
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/delegates/TransactionalTaskController.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/delegates/TransactionalTaskController.java
@@ -70,4 +70,10 @@ public class TransactionalTaskController implements TaskController {
     public void delete(String name) {
         delegate.delete(name);
     }
+
+    @Override
+    @Transactional
+    public void markForDisposal(String name, boolean pokeCleaner) {
+        delegate.markForDisposal(name, pokeCleaner);
+    }
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/delegates/TransactionalTaskController.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/delegates/TransactionalTaskController.java
@@ -20,10 +20,12 @@ package org.jboss.pnc.rex.core.delegates;
 import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
 
+import io.quarkus.arc.Unremovable;
 import org.jboss.pnc.rex.common.enums.Mode;
 import org.jboss.pnc.rex.core.api.TaskController;
 
 @WithTransactions
+@Unremovable
 @ApplicationScoped
 public class TransactionalTaskController implements TaskController {
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/ControllerJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/ControllerJob.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.rex.core.jobs;
 
+import lombok.Getter;
 import org.jboss.pnc.rex.model.Task;
 
 import javax.enterprise.event.TransactionPhase;
@@ -35,10 +36,12 @@ import java.util.Optional;
  */
 public abstract class ControllerJob implements Runnable {
 
+    @Getter
     protected TransactionPhase invocationPhase;
 
     protected Task context;
 
+    @Getter
     protected boolean async;
 
     private boolean completed = false;
@@ -75,13 +78,6 @@ public abstract class ControllerJob implements Runnable {
 
     abstract void onFailure();
     abstract void onException(Throwable e);
-
-    public boolean isAsync() {
-        return async;
-    }
-    public TransactionPhase getInvocationPhase() {
-        return invocationPhase;
-    }
 
     public Optional<Task> getContext() {
         return context == null ? Optional.empty() : Optional.of(context);

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/MarkForCleaningJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/MarkForCleaningJob.java
@@ -1,0 +1,69 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.core.jobs;
+
+import org.jboss.pnc.rex.core.api.TaskController;
+import org.jboss.pnc.rex.model.Task;
+
+import javax.enterprise.event.TransactionPhase;
+import javax.enterprise.inject.spi.CDI;
+
+public class MarkForCleaningJob extends ControllerJob {
+
+    private final TaskController controller;
+
+    private static final TransactionPhase INVOCATION_PHASE = TransactionPhase.IN_PROGRESS;
+
+    private final boolean pokeCleaner;
+
+    public MarkForCleaningJob(Task context, boolean pokeCleaner) {
+        super(INVOCATION_PHASE, context, false);
+        this.pokeCleaner = pokeCleaner;
+        this.controller = CDI.current().select(TaskController.class).get();
+    }
+
+    public MarkForCleaningJob(Task context) {
+        this(context, false);
+    }
+
+    @Override
+    void beforeExecute() {
+
+    }
+
+    @Override
+    void afterExecute() {
+
+    }
+
+    @Override
+    boolean execute() {
+        controller.markForDisposal(context.getName(), pokeCleaner);
+        return true;
+    }
+
+    @Override
+    void onFailure() {
+
+    }
+
+    @Override
+    void onException(Throwable e) {
+
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/PokeCleanJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/PokeCleanJob.java
@@ -1,0 +1,59 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.core.jobs;
+
+import org.jboss.pnc.rex.core.api.CleaningManager;
+import org.jboss.pnc.rex.core.delegates.WithRetries;
+import org.jboss.pnc.rex.model.Task;
+
+import javax.enterprise.event.TransactionPhase;
+import javax.enterprise.inject.spi.CDI;
+
+public class PokeCleanJob extends ControllerJob {
+
+    private static final TransactionPhase INVOCATION_PHASE = TransactionPhase.AFTER_SUCCESS;
+
+    private final CleaningManager manager;
+
+    public PokeCleanJob(Task context) {
+        super(INVOCATION_PHASE, context, false);
+        this.manager = CDI.current().select(CleaningManager.class, () -> WithRetries.class).get();
+    }
+
+    @Override
+    void beforeExecute() {
+
+    }
+
+    @Override
+    void afterExecute() {
+
+    }
+
+    @Override
+    boolean execute() {
+        manager.tryClean();
+        return true;
+    }
+
+    @Override
+    void onException(Throwable e) {}
+
+    @Override
+    void onFailure() {}
+}

--- a/core/src/main/java/org/jboss/pnc/rex/core/mapper/InitialTaskMapper.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/mapper/InitialTaskMapper.java
@@ -37,6 +37,7 @@ public interface InitialTaskMapper {
     @Mapping(target = "stopFlag", constant = "NONE")
     @Mapping(target = "state", constant = "NEW")
     @Mapping(target = "starting", constant = "false")
+    @Mapping(target = "disposable", constant = "false")
     @Mapping(target = "timestamps", expression = "java( new TreeSet() )")
     // Singular additions
     @Mapping(target = "serverResponse", ignore = true)

--- a/core/src/main/java/org/jboss/pnc/rex/facade/mapper/TaskMapper.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/mapper/TaskMapper.java
@@ -28,7 +28,7 @@ import org.mapstruct.Mapping;
 public interface TaskMapper extends EntityMapper<TaskDTO, Task> {
 
     @Override
-    @BeanMapping(ignoreUnmappedSourceProperties = {"unfinishedDependencies", "serverResponses", "starting", "controllerMode"})
+    @BeanMapping(ignoreUnmappedSourceProperties = {"unfinishedDependencies", "serverResponses", "starting", "controllerMode", "disposable"})
     TaskDTO toDTO(Task dbEntity);
 
     @Override
@@ -38,6 +38,7 @@ public interface TaskMapper extends EntityMapper<TaskDTO, Task> {
     @Mapping(target = "dependant", ignore = true)
     @Mapping(target = "dependency", ignore = true)
     @Mapping(target = "starting", ignore = true)
+    @Mapping(target = "disposable", ignore = true)
     @BeanMapping(ignoreUnmappedSourceProperties = {"stopFlag"})
     Task toDB(TaskDTO dtoEntity);
 }

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -95,7 +95,7 @@ quarkus:
       "com.arjuna.ats.jta":
         # Set to WARN if you want to see all the exceptions
         level: ERROR
-    min-level: FINEST
+    min-level: TRACE
 
   vertx:
     max-event-loop-execute-time: 10s

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -118,6 +118,10 @@ org:
             TolerantQueueManager/setMaximumConcurrency/Retry/delay: ${scheduler.options.internal-retry-policy.delay}
             TolerantQueueManager/setMaximumConcurrency/Retry/jitter: ${scheduler.options.internal-retry-policy.jitter}
             TolerantQueueManager/setMaximumConcurrency/Retry/abortOn: ${scheduler.options.internal-retry-policy.abort-on}
+            TolerantCleaningManager/tryClean/Retry/maxRetries: ${scheduler.options.internal-retry-policy.max-retries}
+            TolerantCleaningManager/tryClean/Retry/delay: ${scheduler.options.internal-retry-policy.delay}
+            TolerantCleaningManager/tryClean/Retry/jitter: ${scheduler.options.internal-retry-policy.jitter}
+            TolerantCleaningManager/tryClean/Retry/abortOn: ${scheduler.options.internal-retry-policy.abort-on}
         rest:
           InternalEndpointImpl/finish/Retry/maxRetries: ${scheduler.options.internal-retry-policy.max-retries}
           InternalEndpointImpl/finish/Retry/delay: ${scheduler.options.internal-retry-policy.delay}

--- a/model/src/main/java/org/jboss/pnc/rex/model/Task.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/Task.java
@@ -154,6 +154,15 @@ public class Task {
     @Getter(onMethod_ = @ProtoField(number = 16, collectionImplementation = TreeSet.class))
     private Set<TransitionTime> timestamps;
 
+    /**
+     * This flag indicates that this task can be removed from ISPN Cache. Usually a Task flagged to be removed after a
+     * Notification completes or, in case no Notifications, immediately after transitioning into a finished State.
+     *
+     * Even though a Task can be flagged disposable, it won't be removed until all dependants are removed beforehand.
+     */
+    @Getter(onMethod_ = @ProtoField(number = 17, defaultValue = "false"))
+    private boolean disposable;
+
     public void incUnfinishedDependencies() {
         unfinishedDependencies++;
     }
@@ -161,6 +170,7 @@ public class Task {
     public void decUnfinishedDependencies() {
         unfinishedDependencies--;
     }
+
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
Added a CleaningManager that deletes all Tasks that can be deleted. CleaningManager can be triggered by PokeCleanJob. 

To avoid tasks being deleted by other tasks even without successful notification, all tasks have to be marked as disposable before being able to be deleted. A task is marked as disposable after a successful notification.

Successful marking can trigger a CleaningManager.