### PR TITLE
[NCL-8032] pass mdc and otel values to remote entity

### DIFF
--- a/common/src/main/java/org/jboss/pnc/rex/common/util/MDCUtils.java
+++ b/common/src/main/java/org/jboss/pnc/rex/common/util/MDCUtils.java
@@ -1,0 +1,60 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.common.util;
+
+import org.slf4j.MDC;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MDCUtils {
+
+    public static void applyMDCsFromHeadersMM(List<String> mdcKeys, Map<String, List<String>> headers) {
+        if (mdcKeys == null) {
+            return;
+        }
+
+        for (var key : mdcKeys) {
+            var headerValues = headers.get(key);
+            if (headerValues != null && !headerValues.isEmpty()) {
+                MDC.put(key, headerValues.stream().reduce((str1, str2) -> str1 + "," + str2).get());
+            }
+        }
+    }
+
+    public static void applyMDCsFromHeaders(List<String> mdcKeys, Map<String, String> headers) {
+        Map<String, List<String>> mapWithList = headers.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> List.of(entry.getValue())));
+
+        MDCUtils.applyMDCsFromHeadersMM(mdcKeys, mapWithList);
+    }
+
+    public static void wrapWithMDC(List<String> mdcKeys, Map<String, String> headers, Runnable runnable) {
+        try {
+            MDCUtils.applyMDCsFromHeaders(mdcKeys, headers);
+
+            runnable.run();
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/rex/core/devmode/TokensAlternative.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/devmode/TokensAlternative.java
@@ -15,28 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.rex.core;
+package org.jboss.pnc.rex.core.devmode;
 
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.arc.profile.IfBuildProfile;
 import io.quarkus.oidc.client.Tokens;
+import io.vertx.core.json.JsonObject;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import java.time.Duration;
 
 @ApplicationScoped
-public class BeanFactory {
-
-    /**
-     * Return a mock Tokens object to make the gods of CI happy
-     * @return Tokens object
-     */
+@LookupIfProperty(name = "quarkus.oidc-client.enabled", stringValue = "false")
+@IfBuildProfile(anyOf = {"dev", "test"})
+/**
+ * To be able to start in development/test mode without authorization
+ */
+public class TokensAlternative {
     @Produces
-    public Tokens getToken() {
-        return new Tokens(
-                "abcd",
-                0L,
-                null,
-                "abcd",
-                0L,
-                null);
+    public Tokens produceToken() {
+        return new Tokens("access-token",
+                Long.MAX_VALUE,
+                Duration.ofNanos(Long.MAX_VALUE),
+                "refresh-token",
+                Long.MAX_VALUE, JsonObject.of());
     }
 }

--- a/core/src/main/java/org/jboss/pnc/rex/facade/mapper/ConfigurationMapper.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/mapper/ConfigurationMapper.java
@@ -20,13 +20,21 @@ package org.jboss.pnc.rex.facade.mapper;
 import org.jboss.pnc.rex.dto.ConfigurationDTO;
 import org.jboss.pnc.rex.model.Configuration;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
-@Mapper(config = MapperCentralConfig.class)
+import static org.jboss.pnc.rex.model.Configuration.*;
+
+@Mapper(config = MapperCentralConfig.class,
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
 public interface ConfigurationMapper extends EntityMapper<ConfigurationDTO, Configuration> {
 
     @Override
     ConfigurationDTO toDTO(Configuration dbEntity);
 
     @Override
+    @Mapping(target = "passResultsOfDependencies", defaultValue = "" + Defaults.passResultsOfDependencies)
+    @Mapping(target = "passMDCInRequestBody", defaultValue = "" + Defaults.passMDCInRequestBody)
+    @Mapping(target = "passOTELInRequestBody", defaultValue = "" + Defaults.passOTELInRequestBody)
     Configuration toDB(ConfigurationDTO dtoEntity);
 }

--- a/core/src/main/java/org/jboss/pnc/rex/facade/mapper/CreateTaskMapper.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/mapper/CreateTaskMapper.java
@@ -23,7 +23,7 @@ import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(config = MapperCentralConfig.class, uses = {RequestMapper.class})
+@Mapper(config = MapperCentralConfig.class, uses = {RequestMapper.class, ConfigurationMapper.class})
 public interface CreateTaskMapper extends EntityMapper<CreateTaskDTO, InitialTask> {
 
     @Override

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -211,6 +211,8 @@ org:
     oidc:
       enabled: false
       auth-server-url: ""
+    oidc-client:
+      enabled: false
     transaction-manager:
       default-transaction-timeout: 10m
     opentelemetry:

--- a/core/src/test/java/org/jboss/pnc/rex/core/TaskContainerImplTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/TaskContainerImplTest.java
@@ -522,7 +522,6 @@ class TaskContainerImplTest {
      * Disabled for test determinism reasons
      */
     @RepeatedTest(100)
-    @Disabled
     public void randomDAGTest() throws Exception {
         CreateGraphRequest randomDAG = generateDAG(2, 10, 5, 10, 0.7F);
         taskEndpoint.start(randomDAG);
@@ -551,7 +550,7 @@ class TaskContainerImplTest {
                         .name("service2")
                         .remoteStart(getRequestWithStart("I am service2!"))
                         .remoteCancel(getStopRequestWithCallback("I am service2!"))
-                        .configuration(new ConfigurationDTO(true))
+                        .configuration(new ConfigurationDTO(true, false, false, null))
                         .build())
                 .build());
 
@@ -587,7 +586,7 @@ class TaskContainerImplTest {
                         .name("service2")
                         .remoteStart(getRequestWithStart("I am service2!"))
                         .remoteCancel(getStopRequestWithCallback("I am service2!"))
-                        .configuration(new ConfigurationDTO(false))
+                        .configuration(new ConfigurationDTO(false, false, false, null))
                         .build())
                 .build());
 

--- a/core/src/test/java/org/jboss/pnc/rex/core/common/TestData.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/common/TestData.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.rex.core.common;
 import org.jboss.pnc.rex.api.parameters.TaskFilterParameters;
 import org.jboss.pnc.rex.common.enums.Method;
 import org.jboss.pnc.rex.common.enums.Mode;
+import org.jboss.pnc.rex.dto.ConfigurationDTO;
 import org.jboss.pnc.rex.dto.CreateTaskDTO;
 import org.jboss.pnc.rex.dto.EdgeDTO;
 import org.jboss.pnc.rex.dto.requests.CreateGraphRequest;
@@ -27,6 +28,8 @@ import org.jboss.pnc.rex.model.Header;
 import org.jboss.pnc.rex.model.Request;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TestData {
@@ -72,12 +75,17 @@ public class TestData {
     }
 
     public static CreateTaskDTO createMockTask(String name, Mode mode, org.jboss.pnc.api.dto.Request startRequest, org.jboss.pnc.api.dto.Request stopRequest, org.jboss.pnc.api.dto.Request notificationsRequest) {
+        return createMockTask(name, mode, startRequest, stopRequest, notificationsRequest, null);
+    }
+
+    public static CreateTaskDTO createMockTask(String name, Mode mode, org.jboss.pnc.api.dto.Request startRequest, org.jboss.pnc.api.dto.Request stopRequest, org.jboss.pnc.api.dto.Request notificationsRequest, ConfigurationDTO config) {
         return CreateTaskDTO.builder()
                 .name(name)
                 .controllerMode(mode)
                 .remoteStart(startRequest)
                 .remoteCancel(stopRequest)
                 .callerNotifications(notificationsRequest)
+                .configuration(config)
                 .build();
     }
 
@@ -109,10 +117,16 @@ public class TestData {
     }
 
     public static org.jboss.pnc.api.dto.Request getRequestWithStart(Object payload) {
+        return getRequestWithStart(payload, List.of());
+    }
+    public static org.jboss.pnc.api.dto.Request getRequestWithStart(Object payload, List<org.jboss.pnc.api.dto.Request.Header> headers) {
+        var headerList = new ArrayList<>(headers);
+        headerList.add(new org.jboss.pnc.api.dto.Request.Header("Content-Type", "application/json"));
+
         return org.jboss.pnc.api.dto.Request.builder()
                 .uri(URI.create("http://localhost:8081/test/acceptAndStart"))
                 .method(org.jboss.pnc.api.dto.Request.Method.POST)
-                .headers(List.of(new org.jboss.pnc.api.dto.Request.Header("Content-Type", "application/json")))
+                .headers(headerList)
                 .attachment(payload)
                 .build();
     }

--- a/dto/src/main/java/org/jboss/pnc/rex/dto/ConfigurationDTO.java
+++ b/dto/src/main/java/org/jboss/pnc/rex/dto/ConfigurationDTO.java
@@ -23,6 +23,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.util.List;
+
 /**
  * Class to specify metadata for a Task.
  */
@@ -33,5 +35,11 @@ import lombok.ToString;
 @ToString
 public class ConfigurationDTO {
 
-    public boolean passResultsOfDependencies = false;
+    public Boolean passResultsOfDependencies = null;
+
+    public Boolean passMDCInRequestBody = null;
+
+    public Boolean passOTELInRequestBody = null;
+
+    public List<String> mdcHeaderKeys = null;
 }

--- a/dto/src/main/java/org/jboss/pnc/rex/dto/requests/CreateGraphRequest.java
+++ b/dto/src/main/java/org/jboss/pnc/rex/dto/requests/CreateGraphRequest.java
@@ -22,6 +22,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Singular;
+import org.jboss.pnc.rex.dto.ConfigurationDTO;
 import org.jboss.pnc.rex.dto.CreateTaskDTO;
 import org.jboss.pnc.rex.dto.EdgeDTO;
 
@@ -31,19 +32,19 @@ import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;
 
+@Getter
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateGraphRequest {
 
-    @Getter
     public String correlationID;
 
-    @Getter
+    public ConfigurationDTO graphConfiguration;
+
     @Singular
     public Set<@NotNull @Valid EdgeDTO> edges;
 
-    @Getter
     @Singular
     public Map<@NotBlank String, @NotNull @Valid CreateTaskDTO> vertices;
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/Configuration.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/Configuration.java
@@ -25,10 +25,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoField;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Class to specify metadata for a Task.
  */
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor(onConstructor_ = {@ProtoFactory})
 @Slf4j
 @Jacksonized
@@ -37,7 +40,21 @@ public class Configuration {
     /**
      * Specify whether we want to pass results of direct dependencies in the StartRequest and StopRequest
      */
-    @Getter(onMethod_ = {@ProtoField(number = 1, defaultValue = "false")})
+    @Getter(onMethod_ = {@ProtoField(number = 1, defaultValue = "" + Defaults.passResultsOfDependencies)})
     private final boolean passResultsOfDependencies;
 
+    @Getter(onMethod_ = {@ProtoField(number = 2, defaultValue = "" + Defaults.passMDCInRequestBody)})
+    private final boolean passMDCInRequestBody;
+
+    @Getter(onMethod_ = {@ProtoField(number = 3, defaultValue = "" + Defaults.passOTELInRequestBody)})
+    private final boolean passOTELInRequestBody;
+
+    @Getter(onMethod_ = {@ProtoField(number = 4, collectionImplementation = ArrayList.class)})
+    private final List<String> mdcHeaderKeys;
+
+    public static class Defaults {
+        public static final boolean passResultsOfDependencies = false;
+        public static final boolean passMDCInRequestBody = false;
+        public static final boolean passOTELInRequestBody = false;
+    }
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/TransitionTime.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/TransitionTime.java
@@ -27,6 +27,10 @@ import org.infinispan.protostream.annotations.ProtoField;
 import org.jboss.pnc.rex.common.enums.Transition;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 
 @Builder
 @Jacksonized
@@ -42,5 +46,19 @@ public class TransitionTime implements Comparable<TransitionTime> {
     @Override
     public int compareTo(TransitionTime other) {
         return this.getTime().compareTo(other.getTime());
+    }
+
+    @Override
+    public String toString() {
+        return "[ " + transition + " at " + formatTime(time) + " ]";
+    }
+
+    /**
+     * f.e. 9/12/23, 5:56:49 PM CEST
+     * @return formatted time
+     */
+    private String formatTime(Instant time) {
+        return DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT, FormatStyle.LONG)
+                .format(ZonedDateTime.ofInstant(time, ZoneId.systemDefault()));
     }
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/StartRequest.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/StartRequest.java
@@ -54,5 +54,7 @@ public class StartRequest {
 
     private final Object payload;
 
+    private final Map<String, String> mdc;
+
     private final Map<String, Object> taskResults;
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequest.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequest.java
@@ -52,8 +52,9 @@ public class StopRequest {
      */
     private final org.jboss.pnc.api.dto.Request negativeCallback;
 
-
     private final Object payload;
+
+    private final Map<String, String> mdc;
 
     private final Map<String, Object> taskResults;
 }


### PR DESCRIPTION
Couple things done:

1. Introduced configuration on CreateGraphRequest level (graph-level) so that it is easier to specify **common** configration for all Tasks in the request. Deviations from common config can be overriden with Task's own configuration. 
2. Redone the fields ConfigurationDTO so that we can have them null (only null fields are looked upon from graph config)
3. _mdcHeaderKeys_
     - specify which headers should be taken into MDC context (for centralized logging)
5. _passMDCInRequestBody_
     - put MDC values from threadcontext into body (for RHPAM)
     - these MDC values are from mdcHeaderKeys
6. _passOTELInRequestBody_
     - put OTEL values from Rex's context into body (also under .mdc, not the best place, we've agreed with Matej on it)