### PR TITLE
[NCL-8032] provide error response in case of internal system failures

### DIFF
--- a/common/src/main/java/org/jboss/pnc/rex/common/enums/Origin.java
+++ b/common/src/main/java/org/jboss/pnc/rex/common/enums/Origin.java
@@ -15,28 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.rex.dto;
+package org.jboss.pnc.rex.common.enums;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import org.jboss.pnc.rex.common.enums.Origin;
-import org.jboss.pnc.rex.common.enums.State;
 
-@Getter
-@Builder
-@ToString
-@NoArgsConstructor
-@AllArgsConstructor
-public class ServerResponseDTO {
+import org.infinispan.protostream.annotations.ProtoEnumValue;
 
-    public State state;
+public enum Origin {
 
-    public Boolean positive;
+    /**
+     * The response originates from a external remote entitu. This response signifies a callback for start/cancel
+     * operations.
+     */
+    @ProtoEnumValue(number = 0)
+    REMOTE_ENTITY,
 
-    public Object body;
-
-    public Origin origin;
+    /**
+     * A response for the transition originates in Rex itself. The generated response contains an error with the reason
+     * for failure.
+     *
+     * An example of a failure can be failed invocation of remote entity whilst starting/cancelling.
+     */
+    @ProtoEnumValue(number = 1)
+    REX_INTERNAL_ERROR
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/api/TaskController.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/api/TaskController.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.rex.core.api;
 
 import org.jboss.pnc.rex.common.enums.Mode;
+import org.jboss.pnc.rex.common.enums.Origin;
 
 /**
  * This is API for TaskController.
@@ -51,19 +52,23 @@ public interface TaskController {
 
     /**
      * Method used for positive callback. Needs to be called in a transaction.
-     *
+     * <p>
      * f.e. to signalize that remote Task has started/cancelled/finished.
-     * @param name id of the Task
+     *
+     * @param name   id of the Task
+     * @param origin the origin of response
      */
-    void accept(String name, Object response);
+    void accept(String name, Object response, Origin origin);
 
     /**
      * Method used for negative callback. Needs to be called in a transaction.
-     *
+     * <p>
      * f.e. to signalize that remote Task failed to start/cancel or failed during execution.
-     * @param name id of the Task
+     *
+     * @param name   id of the Task
+     * @param origin the origin of response
      */
-    void fail(String name, Object response);
+    void fail(String name, Object response, Origin origin);
 
     void dequeue(String name);
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/delegates/TransactionalTaskController.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/delegates/TransactionalTaskController.java
@@ -22,6 +22,7 @@ import javax.transaction.Transactional;
 
 import io.quarkus.arc.Unremovable;
 import org.jboss.pnc.rex.common.enums.Mode;
+import org.jboss.pnc.rex.common.enums.Origin;
 import org.jboss.pnc.rex.core.api.TaskController;
 
 @WithTransactions
@@ -49,14 +50,14 @@ public class TransactionalTaskController implements TaskController {
 
     @Override
     @Transactional
-    public void accept(String name, Object response) {
-        delegate.accept(name, response);
+    public void accept(String name, Object response, Origin origin) {
+        delegate.accept(name, response, origin);
     }
 
     @Override
     @Transactional
-    public void fail(String name, Object response) {
-        delegate.fail(name, response);
+    public void fail(String name, Object response, Origin origin) {
+        delegate.fail(name, response, origin);
     }
 
     @Override

--- a/core/src/main/java/org/jboss/pnc/rex/core/devmode/TokensAlternative.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/devmode/TokensAlternative.java
@@ -29,7 +29,7 @@ import java.time.Duration;
 @ApplicationScoped
 @LookupIfProperty(name = "quarkus.oidc-client.enabled", stringValue = "false")
 @IfBuildProfile(anyOf = {"dev", "test"})
-/**
+/*
  * To be able to start in development/test mode without authorization
  */
 public class TokensAlternative {
@@ -39,6 +39,7 @@ public class TokensAlternative {
                 Long.MAX_VALUE,
                 Duration.ofNanos(Long.MAX_VALUE),
                 "refresh-token",
-                Long.MAX_VALUE, JsonObject.of());
+                Long.MAX_VALUE,
+                JsonObject.of());
     }
 }

--- a/core/src/main/java/org/jboss/pnc/rex/core/infinispan/protobuf/ProtoSchemaGenerator.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/infinispan/protobuf/ProtoSchemaGenerator.java
@@ -21,6 +21,7 @@ import org.infinispan.protostream.GeneratedSchema;
 import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
 import org.jboss.pnc.rex.common.enums.Method;
 import org.jboss.pnc.rex.common.enums.Mode;
+import org.jboss.pnc.rex.common.enums.Origin;
 import org.jboss.pnc.rex.common.enums.State;
 import org.jboss.pnc.rex.common.enums.StopFlag;
 import org.jboss.pnc.rex.common.enums.Transition;
@@ -47,6 +48,7 @@ import org.jboss.pnc.rex.model.ispn.adapter.KeyValueString;
                 Mode.class,
                 State.class,
                 StopFlag.class,
+                Origin.class,
                 Request.class,
                 Configuration.class,
                 Transition.class,

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStartJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStartJob.java
@@ -18,6 +18,8 @@
 package org.jboss.pnc.rex.core.jobs;
 
 import io.smallrye.mutiny.Uni;
+import org.jboss.pnc.api.dto.ErrorResponse;
+import org.jboss.pnc.rex.common.enums.Origin;
 import org.jboss.pnc.rex.core.RemoteEntityClient;
 import org.jboss.pnc.rex.core.api.TaskController;
 import org.jboss.pnc.rex.core.delegates.WithTransactions;
@@ -65,7 +67,7 @@ public class InvokeStartJob extends ControllerJob {
     void onException(Throwable e) {
         logger.error("STOP " + context.getName() + ": UNEXPECTED exception has been thrown.", e);
         Uni.createFrom().voidItem()
-                .onItem().invoke((ignore) -> controller.fail(context.getName(), "START : System failure. Exception: " + e.toString()))
+                .onItem().invoke((ignore) -> controller.fail(context.getName(), new ErrorResponse(e, "Rex failed to start a Task on the remote entity."), Origin.REX_INTERNAL_ERROR))
                 .onFailure().invoke((throwable) -> logger.warn("START " + context.getName() + ": Failed to transition task to START_FAILED state. Retrying.", throwable))
                 .onFailure().retry().atMost(5)
                 .onFailure().recoverWithNull()

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStopJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/InvokeStopJob.java
@@ -18,6 +18,8 @@
 package org.jboss.pnc.rex.core.jobs;
 
 import io.smallrye.mutiny.Uni;
+import org.jboss.pnc.api.dto.ErrorResponse;
+import org.jboss.pnc.rex.common.enums.Origin;
 import org.jboss.pnc.rex.core.RemoteEntityClient;
 import org.jboss.pnc.rex.core.api.TaskController;
 import org.jboss.pnc.rex.core.delegates.WithTransactions;
@@ -48,7 +50,7 @@ public class InvokeStopJob extends ControllerJob {
     void onException(Throwable e) {
         logger.error("STOP " + context.getName() + ": UNEXPECTED exception has been thrown.", e);
         Uni.createFrom().voidItem()
-                .onItem().invoke((ignore) -> controller.fail(context.getName(), "STOP : System failure. Exception: " + e.toString()))
+                .onItem().invoke((ignore) -> controller.fail(context.getName(), new ErrorResponse(e, "Rex couldn't invoke cancel on the remote entity."), Origin.REX_INTERNAL_ERROR))
                 .onFailure().invoke((throwable) -> logger.warn("STOP " + context.getName() + ": Failed to transition task to STOP_FAILED state. Retrying.", throwable))
                 .onFailure().retry().atMost(5)
                 .onFailure().recoverWithNull()

--- a/core/src/main/java/org/jboss/pnc/rex/facade/TaskProviderImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/TaskProviderImpl.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.rex.facade;
 
 import org.jboss.pnc.rex.common.enums.Mode;
+import org.jboss.pnc.rex.common.enums.Origin;
 import org.jboss.pnc.rex.common.exceptions.TaskMissingException;
 import org.jboss.pnc.rex.common.util.MDCUtils;
 import org.jboss.pnc.rex.core.api.TaskContainer;
@@ -127,9 +128,9 @@ public class TaskProviderImpl implements TaskProvider {
     @Transactional
     public void acceptRemoteResponse(String taskName, boolean positive, Object response) {
         if (positive) {
-            controller.accept(taskName, response);
+            controller.accept(taskName, response, Origin.REMOTE_ENTITY);
         } else {
-            controller.fail(taskName, response);
+            controller.fail(taskName, response, Origin.REMOTE_ENTITY);
         }
     }
 }

--- a/core/src/test/java/org/jboss/pnc/rex/core/TaskContainerImplTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/core/TaskContainerImplTest.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.infinispan.client.hotrod.VersionedValue;
 import org.jboss.pnc.rex.api.TaskEndpoint;
 import org.jboss.pnc.rex.common.enums.Mode;
+import org.jboss.pnc.rex.common.enums.Origin;
 import org.jboss.pnc.rex.common.enums.State;
 import org.jboss.pnc.rex.common.exceptions.BadRequestException;
 import org.jboss.pnc.rex.common.exceptions.CircularDependencyException;
@@ -234,7 +235,7 @@ class TaskContainerImplTest {
         waitTillTasksAre(State.UP, container, EXISTING_KEY);
 
         container.getTransactionManager().begin();
-        controller.accept(EXISTING_KEY, null);
+        controller.accept(EXISTING_KEY, null, Origin.REMOTE_ENTITY);
         container.getTransactionManager().commit();
 
         waitTillTasksAre(State.UP, container, dependant);

--- a/model/src/main/java/org/jboss/pnc/rex/model/ServerResponse.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/ServerResponse.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoField;
 import org.infinispan.protostream.descriptors.Type;
+import org.jboss.pnc.rex.common.enums.Origin;
 import org.jboss.pnc.rex.common.enums.State;
 
 import java.io.IOException;
@@ -53,10 +54,14 @@ public class ServerResponse {
     @Getter
     private final Object body;
 
+    @Getter(onMethod_ = {@ProtoField(number = 4, type = Type.ENUM)})
+    private final Origin origin;
+
     @ProtoFactory
-    public ServerResponse(State state, boolean positive, byte[] byteBody) {
+    public ServerResponse(State state, boolean positive, byte[] byteBody, Origin origin) {
         this.state = state;
         this.positive = positive;
+        this.origin = origin;
         Object body;
         try {
             body = convertToObject(byteBody);


### PR DESCRIPTION
For edge cases, when there are errors contacting remote-entity (RHPAM), Rex will save an error response with a reason for the failure.
 
 The enum Origin will help differentiate whether the response came from internal failure or is standard response from remote entity.
 
 The recipients of notifications(Orch) can read the error response and react accordingly. 