### PR TITLE
add QueryParam in CallbackEndpoint.java to ignore Missing task

### DIFF
--- a/api/src/main/java/org/jboss/pnc/rex/api/CallbackEndpoint.java
+++ b/api/src/main/java/org/jboss/pnc/rex/api/CallbackEndpoint.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.pnc.rex.api;
 
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -24,6 +26,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.pnc.rex.api.openapi.OpenapiConstants;
+import org.jboss.pnc.rex.api.parameters.ErrorOption;
 import org.jboss.pnc.rex.dto.requests.FinishRequest;
 import org.jboss.pnc.rex.dto.responses.ErrorResponse;
 
@@ -61,7 +64,9 @@ public interface CallbackEndpoint {
     })
     @POST
     @Deprecated
-    void finish(@PathParam("taskName") @NotEmpty String taskName, @Valid @NotNull FinishRequest result);
+    void finish(@PathParam("taskName") @NotEmpty String taskName,
+                @Valid @NotNull FinishRequest result,
+                @QueryParam("err") @DefaultValue("PASS_ERROR") ErrorOption err);
 
     String OPERATION_SUCCESSFUL = "/{taskName}/succeed";
     @Path(OPERATION_SUCCESSFUL)
@@ -74,7 +79,9 @@ public interface CallbackEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    void succeed(@PathParam("taskName") @NotEmpty String taskName, Object result);
+    void succeed(@PathParam("taskName") @NotEmpty String taskName,
+                 Object result,
+                 @QueryParam("err") @DefaultValue("PASS_ERROR") ErrorOption err);
 
     String OPERATION_FAILED = "/{taskName}/fail";
     @Path(OPERATION_FAILED)
@@ -87,5 +94,7 @@ public interface CallbackEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    void fail(@PathParam("taskName") @NotEmpty String taskName, Object result);
+    void fail(@PathParam("taskName") @NotEmpty String taskName,
+              Object result,
+              @QueryParam("err") @DefaultValue("PASS_ERROR") ErrorOption err);
 }

--- a/api/src/main/java/org/jboss/pnc/rex/api/parameters/ErrorOption.java
+++ b/api/src/main/java/org/jboss/pnc/rex/api/parameters/ErrorOption.java
@@ -1,0 +1,32 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021-2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rex.api.parameters;
+
+public enum ErrorOption {
+    /**
+     * DEFAULT option
+     *
+     * In case there are unrecoverable errors, return ErrorResponse and appropriate status code.
+     */
+    PASS_ERROR,
+
+    /**
+     * In some cases (TaskMissing) return positive status code even if it's not default behaviour.
+     */
+    IGNORE
+}

--- a/core/src/test/java/org/jboss/pnc/rex/test/ValidationTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/test/ValidationTest.java
@@ -24,6 +24,7 @@ import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
 import org.jboss.pnc.rex.api.CallbackEndpoint;
 import org.jboss.pnc.rex.api.TaskEndpoint;
+import org.jboss.pnc.rex.api.parameters.ErrorOption;
 import org.jboss.pnc.rex.common.enums.Mode;
 import org.jboss.pnc.rex.dto.EdgeDTO;
 import org.jboss.pnc.rex.dto.requests.CreateGraphRequest;
@@ -161,4 +162,16 @@ public class ValidationTest {
                     .body("errorType", containsString("ViolationException"));
     }
 
+    @Test
+    void shouldNotFailOnMissingTaskIfIgnoreSpecified() {
+        FinishRequest request = new FinishRequest(true,"HELLO");
+        given()
+            .when()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .queryParam("err", ErrorOption.IGNORE) // IGNORE should make the response 204
+                .post(callbackEndpointURI.getPath() + CallbackEndpoint.FINISH_TASK_FMT.formatted( "doesn't-exist"))
+            .then()
+                .statusCode(204);
+    }
 }


### PR DESCRIPTION
This is for RHPAM so that it doesn't retry the process.