### PR TITLE
Remove quarkus-rest-client-reactive-jackson

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -110,10 +110,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-jib</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This dependency is not used in the core module and it is also removed in later versions of Quarkus (replaced by quarkus-rest-client-jackson)

Reference: https://quarkus.io/extensions/io.quarkus/quarkus-rest-client-reactive-jackson/