### PR TITLE
Add endpoint cancelByCorrelationId

### DIFF
--- a/api/src/main/java/org/jboss/pnc/rex/api/TaskEndpoint.java
+++ b/api/src/main/java/org/jboss/pnc/rex/api/TaskEndpoint.java
@@ -123,6 +123,21 @@ public interface TaskEndpoint {
     @PUT
     Response cancel(@Parameter(description = TASK_ID) @PathParam("taskID") @NotBlank String taskID);
 
+    String CANCEL_BY_CORRELATION_ID = "/by-correlation/{correlationID}/cancel";
+    @Path(CANCEL_BY_CORRELATION_ID)
+    @Operation(summary = "Cancels execution of all the tasks belonging to a correlationID")
+    @APIResponses(value = {
+            @APIResponse(responseCode = OpenapiConstants.ACCEPTED_CODE, description = OpenapiConstants.ACCEPTED_CODE),
+            @APIResponse(responseCode = OpenapiConstants.INVALID_CODE, description = OpenapiConstants.INVALID_DESCRIPTION,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(responseCode = OpenapiConstants.NOT_FOUND_CODE, description = OpenapiConstants.NOT_FOUND_DESCRIPTION,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @APIResponse(responseCode = OpenapiConstants.SERVER_ERROR_CODE, description = OpenapiConstants.SERVER_ERROR_DESCRIPTION,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PUT
+    Response cancelByCorrelationID(@PathParam("correlationID") @NotBlank String correlationID);
+
     String GET_BY_CORRELATION_ID = "/by-correlation/{correlationID}";
     @Path(GET_BY_CORRELATION_ID)
     @GET

--- a/core/src/main/java/org/jboss/pnc/rex/facade/TaskProviderImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/TaskProviderImpl.java
@@ -104,6 +104,14 @@ public class TaskProviderImpl implements TaskProvider {
     }
 
     @Override
+    @Transactional
+    public void cancelByCorrelationID(String correlationID) {
+        registry.getTasksByCorrelationID(correlationID).stream()
+                .map(Task::getName)
+                .forEach(taskName -> controller.setMode(taskName, Mode.CANCEL));
+    }
+
+    @Override
     public TaskDTO get(String taskName) {
         Task task;
         try {

--- a/core/src/main/java/org/jboss/pnc/rex/facade/api/TaskProvider.java
+++ b/core/src/main/java/org/jboss/pnc/rex/facade/api/TaskProvider.java
@@ -42,6 +42,13 @@ public interface TaskProvider {
     void cancel(String taskName);
 
     /**
+     * Cancels execution of all the tasks in the correlationID
+     *
+     * @param correlationID the correlationID of the tasks to cancel
+     */
+    void cancelByCorrelationID(String correlationID);
+
+    /**
      * Returns existing service based on param
      *
      * @param taskName name of existing service

--- a/core/src/main/java/org/jboss/pnc/rex/rest/TaskEndpointImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/rest/TaskEndpointImpl.java
@@ -76,4 +76,13 @@ public class TaskEndpointImpl implements TaskEndpoint {
 
         return Response.accepted().build();
     }
+
+    @Override
+    @Retry
+    @RolesAllowed({ "pnc-app-rex-editor", "pnc-app-rex-user", "pnc-users-admin" })
+    public Response cancelByCorrelationID(String correlationID) {
+        taskProvider.cancelByCorrelationID(correlationID);
+
+        return Response.accepted().build();
+    }
 }

--- a/core/src/main/resources/META-INF/openapi.json
+++ b/core/src/main/resources/META-INF/openapi.json
@@ -636,6 +636,39 @@
           }
         }
       }
+    },
+    "/rest/tasks/by-correlation/{correlationID}/cancel" : {
+      "put" : {
+        "tags" : [ "Task endpoint" ],
+        "summary" : "Cancels execution of all the tasks belonging to a correlationID",
+        "operationId" : "cancelByCorrelationID",
+        "parameters" : [ {
+          "name" : "correlationID",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\S",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "202" : {
+            "description" : "202"
+          },
+          "400" : {
+            "description" : "Invalid input parameters or validation error",
+            "content" : { }
+          },
+          "404" : {
+            "description" : "Can not find specified result",
+            "content" : { }
+          },
+          "500" : {
+            "description" : "Server error",
+            "content" : { }
+          }
+        }
+      }
     }
   },
   "components" : {

--- a/core/src/main/resources/META-INF/openapi.yaml
+++ b/core/src/main/resources/META-INF/openapi.yaml
@@ -437,6 +437,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ComponentVersion"
+  /rest/tasks/by-correlation/{correlationID}/cancel:
+    put:
+      tags:
+      - Task endpoint
+      summary: Cancels execution of all the tasks belonging to a correlationID
+      operationId: cancelByCorrelationID
+      parameters:
+      - name: correlationID
+        in: path
+        required: true
+        schema:
+          pattern: \S
+          type: string
+      responses:
+        "202":
+          description: "202"
+        "400":
+          description: Invalid input parameters or validation error
+          content: {}
+        "404":
+          description: Can not find specified result
+          content: {}
+        "500":
+          description: Server error
+          content: {}
 components:
   schemas:
     ComponentVersion:


### PR DESCRIPTION
We currently have the ability to cancel a task and all of its dependants. This commit adds the ability to cancel all the tasks with the same correlation id.

This reduces the number of requests a client have to do to Rex to cancel all the tasks inside a correlation id. An example is the cancellation of a build set in Project Newcastle, which currently just iterates through each build to
[cancel](https://github.com/project-ncl/pnc/blob/b9669dfe0e2f0872f14db98b1d9af6b85a8c34c3/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/builder/RemoteBuildCoordinator.java#L461) all the builds in the build set.