### PR TITLE
Make taskResults return a map of <String, ServerResponse>

### DIFF
--- a/core/src/main/java/org/jboss/pnc/rex/core/RemoteEntityClient.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/RemoteEntityClient.java
@@ -30,9 +30,11 @@ import org.jboss.pnc.rex.core.api.TaskController;
 import org.jboss.pnc.rex.core.api.TaskRegistry;
 import org.jboss.pnc.rex.core.config.ApplicationConfig;
 import org.jboss.pnc.rex.core.delegates.WithTransactions;
+import org.jboss.pnc.rex.dto.ServerResponseDTO;
 import org.jboss.pnc.rex.model.Configuration;
 import org.jboss.pnc.rex.model.Header;
 import org.jboss.pnc.rex.model.Request;
+import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.model.Task;
 import org.jboss.pnc.rex.model.requests.StartRequest;
 import org.jboss.pnc.rex.model.requests.StopRequest;
@@ -258,7 +260,7 @@ public class RemoteEntityClient {
      *
      * @return task results of dependencies
      */
-    private Map<String, Object> getTaskResultsIfConfigurationAllows(Task task) {
+    private Map<String, ServerResponse> getTaskResultsIfConfigurationAllows(Task task) {
         if (task.getConfiguration() != null && task.getConfiguration().isPassResultsOfDependencies()) {
             return taskRegistry.getTaskResults(task);
         } else {

--- a/core/src/main/java/org/jboss/pnc/rex/core/TaskContainerImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/TaskContainerImpl.java
@@ -195,9 +195,9 @@ public class TaskContainerImpl implements TaskContainer, TaskTarget {
         return query.execute().list();
     }
 
-    public Map<String, Object> getTaskResults(Task task) {
+    public Map<String, ServerResponse> getTaskResults(Task task) {
 
-        Map<String, Object> taskResults = new HashMap<>();
+        Map<String, ServerResponse> taskResults = new HashMap<>();
         // tasks that this task depends on
         Set<String> dependencies = task.getDependencies();
 
@@ -212,7 +212,7 @@ public class TaskContainerImpl implements TaskContainer, TaskTarget {
                 taskResults.put(taskName, serverResponses.get(serverResponses.size() - 1));
             } else {
                 // just add an empty object?
-                taskResults.put(taskName, new Object());
+                taskResults.put(taskName, ServerResponse.builder().build());
             }
         }
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/api/TaskRegistry.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/api/TaskRegistry.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.rex.core.api;
 
 import org.jboss.pnc.rex.common.exceptions.TaskMissingException;
+import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.model.Task;
 
 import java.util.Collection;
@@ -69,7 +70,7 @@ public interface TaskRegistry {
      * @param task task to return task results
      * @return Map of taskName and the result
      */
-    Map<String, Object> getTaskResults(Task task);
+    Map<String, ServerResponse> getTaskResults(Task task);
 
     List<Task> getEnqueuedTasks(long limit);
 

--- a/core/src/test/java/org/jboss/pnc/rex/test/TaskContainerImplTest.java
+++ b/core/src/test/java/org/jboss/pnc/rex/test/TaskContainerImplTest.java
@@ -50,6 +50,7 @@ import org.jboss.pnc.rex.common.exceptions.TaskConflictException;
 import org.jboss.pnc.rex.core.TaskContainerImpl;
 import org.jboss.pnc.rex.core.api.QueueManager;
 import org.jboss.pnc.rex.core.api.TaskController;
+import org.jboss.pnc.rex.model.ServerResponse;
 import org.jboss.pnc.rex.test.common.AbstractTest;
 import org.jboss.pnc.rex.core.counter.Counter;
 import org.jboss.pnc.rex.core.counter.Running;
@@ -565,7 +566,7 @@ class TaskContainerImplTest extends AbstractTest {
         Object lastRequest = requests.toArray()[requests.size() - 1];
         StartRequest startRequest = (StartRequest) lastRequest;
 
-        Map<String, Object> taskResults = startRequest.getTaskResults();
+        Map<String, ServerResponse> taskResults = startRequest.getTaskResults();
         assertThat(taskResults).isNotEmpty();
         assertThat(taskResults.keySet()).contains("service1");
         assertThat(taskResults.get("service1")).isNotNull();
@@ -600,7 +601,7 @@ class TaskContainerImplTest extends AbstractTest {
         Object lastRequest = requests.toArray()[requests.size() - 1];
         StartRequest startRequest = (StartRequest) lastRequest;
 
-        Map<String, Object> taskResults = startRequest.getTaskResults();
+        Map<String, ServerResponse> taskResults = startRequest.getTaskResults();
         assertThat(taskResults).isNull();
     }
 

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/StartRequest.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/StartRequest.java
@@ -21,6 +21,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
+import org.jboss.pnc.rex.model.ServerResponse;
 
 import java.util.Map;
 
@@ -56,5 +57,5 @@ public class StartRequest {
 
     private final Map<String, String> mdc;
 
-    private final Map<String, Object> taskResults;
+    private final Map<String, ServerResponse> taskResults;
 }

--- a/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequest.java
+++ b/model/src/main/java/org/jboss/pnc/rex/model/requests/StopRequest.java
@@ -21,6 +21,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
+import org.jboss.pnc.rex.model.ServerResponse;
 
 import java.util.Map;
 
@@ -56,5 +57,5 @@ public class StopRequest {
 
     private final Map<String, String> mdc;
 
-    private final Map<String, Object> taskResults;
+    private final Map<String, ServerResponse> taskResults;
 }


### PR DESCRIPTION
Instead of a map of <String, Object>. We can be more precise on the type of the map for taskResults.