### PR TITLE
[NCLSUP-1283] fix heartbeat transaction retries

### DIFF
--- a/core/src/main/java/org/jboss/pnc/rex/core/ClusteredJobRegistryImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/ClusteredJobRegistryImpl.java
@@ -60,8 +60,8 @@ public class ClusteredJobRegistryImpl implements ClusteredJobRegistry {
     public List<ClusteredJobReference> getByTask(String taskId) {
         QueryFactory factory = Search.getQueryFactory(jobs);
 
-        return factory.<ClusteredJobReference>create("FROM rex_model.ClusteredJobReference WHERE taskId = :taskId")
-            .setParameter("taskId", taskId)
+        return factory.<ClusteredJobReference>create("FROM rex_model.ClusteredJobReference WHERE taskName = :taskName")
+            .setParameter("taskName", taskId)
             .list();
     }
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/HeartbeatVerifierClusterJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/HeartbeatVerifierClusterJob.java
@@ -154,7 +154,6 @@ public class HeartbeatVerifierClusterJob extends ClusteredJob {
         if (failureCount > failureThreshold) {
             log.info("HEARTBEAT {}: Threshold reached, failing Task.", refreshedTask.getName());
             taskController.fail(refreshedTask.getName(), null, Origin.REX_HEARTBEAT_TIMEOUT, false);
-            complete.complete(null);
             return;
         }
 


### PR DESCRIPTION
The verifier thread was getting cancelled without confirmation that the underlying transaction succeeded. I've removed the cancel and let the next iteration of verifying cancel itself on Final state guard check.