### PR TITLE
[NCLSUP-1283][master] fix heartbeat transaction retries

### DIFF
--- a/core/src/main/java/org/jboss/pnc/rex/core/ClusteredJobRegistryImpl.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/ClusteredJobRegistryImpl.java
@@ -54,8 +54,8 @@ public class ClusteredJobRegistryImpl implements ClusteredJobRegistry {
 
     @Override
     public List<ClusteredJobReference> getByTask(String taskId) {
-        return jobs.<ClusteredJobReference>query("FROM rex_model.ClusteredJobReference WHERE taskId = :taskId")
-            .setParameter("taskId", taskId)
+        return jobs.<ClusteredJobReference>query("FROM rex_model.ClusteredJobReference WHERE taskName = :taskName")
+            .setParameter("taskName", taskId)
             .list();
     }
 

--- a/core/src/main/java/org/jboss/pnc/rex/core/jobs/HeartbeatVerifierClusterJob.java
+++ b/core/src/main/java/org/jboss/pnc/rex/core/jobs/HeartbeatVerifierClusterJob.java
@@ -155,7 +155,6 @@ public class HeartbeatVerifierClusterJob extends ClusteredJob {
         if (failureCount > failureThreshold) {
             log.info("HEARTBEAT {}: Threshold reached, failing Task.", refreshedTask.getName());
             taskController.fail(refreshedTask.getName(), null, Origin.REX_HEARTBEAT_TIMEOUT, false);
-            complete.complete(null);
             return;
         }
 


### PR DESCRIPTION
The verifier thread was getting cancelled without confirmation that the underlying transaction succeeded. I've removed the cancel and let the next iteration of verifying cancel itself on Final state guard check.